### PR TITLE
truncates long queries in error pop-up to keep 'ok' button on screen

### DIFF
--- a/sqlite-manager/chrome/resource/sqlite.js
+++ b/sqlite-manager/chrome/resource/sqlite.js
@@ -1071,6 +1071,11 @@ SQLiteHandler.prototype = {
   },
 
   onSqlError: function(ex, msg, SQLmsg, bAlert) {
+	var startOfMessage
+	if (msg.search(/(.*\n){10,}/) > -1) {
+		// msg is more than 10 lines long
+		msg = /(.*\n?){1,10}/.exec(msg)[0] + '...';
+	}
     msg = "SQLiteManager: " + msg;
     if (SQLmsg != null)
       msg += " [ " + SQLmsg + " ]";


### PR DESCRIPTION
Updated chrome/resource/sqlite.js onSqlError function to limit restatement of SQL query to only
first 10 lines for long queries so that the bottom of the alert pop-up stays on screen. A '...' is
appended to the end of truncated queries. Other error information on the pop-up was left alone.
