### PR TITLE
Fix CSV import for Firefox 35

### DIFF
--- a/sqlite-manager/chrome/content/testCsv.js
+++ b/sqlite-manager/chrome/content/testCsv.js
@@ -12,7 +12,7 @@ var SmTestExim = {
     req.overrideMimeType('text/plain; charset=UTF-8');
     req.send(null);
     var contents = "";
-    if(req.status == 0) {
+    if(req.status == 0 || req.status == 200) {
       try {
       contents = JSON.parse(req.responseText);
       }

--- a/sqlite-manager/chrome/content/workerCsv.js
+++ b/sqlite-manager/chrome/content/workerCsv.js
@@ -17,7 +17,7 @@ var gFile = {
     req.open('GET', file, false);
     req.overrideMimeType('text/plain; charset='+charset);
     req.send(null);
-    if(req.status == 0) {
+    if(req.status == 0 || req.status == 200) {
       this.contents = req.responseText;
       this.size = this.contents.length;
     }


### PR DESCRIPTION
The CSV import is now working in Firefox 35 as reported in several issues and on stackoverflow. This should fix the CSV import again.

In Firefox 35 the bug https://bugzilla.mozilla.org/show_bug.cgi?id=716491 was corrected, which means that the code is now 200 and not 0 anymore. The patch should work for both code, i.e. in newer and older version of Firefox.