### PR TITLE
Updated calls to String.replace

### DIFF
--- a/sqlite-manager/chrome/content/createManager.js
+++ b/sqlite-manager/chrome/content/createManager.js
@@ -314,7 +314,7 @@ var CreateManager = {
         if (si.hasAttribute('sm_check')) {
           col["type"] = si.getAttribute('sm_type');
           col["check"] = si.getAttribute('sm_check');
-          col["check"] = col["check"].replace("zzzz", colname, "g");
+          col["check"] = col["check"].replace(/zzzz/g, colname);
         }
       }
       col["pk"] = $$("primarykey-" + i).checked;

--- a/sqlite-manager/chrome/content/exim.js
+++ b/sqlite-manager/chrome/content/exim.js
@@ -220,7 +220,7 @@ var SmExim = {
       var i = 0;
       for(var i in columns) {
         if (cEncloser == "din" || cEncloser == '"') {
-          columns[i][0] = columns[i][0].replace("\"", "\"\"", "g");        
+          columns[i][0] = columns[i][0].replace(/"/g,"\"\"");        
           data.push('"' + columns[i][0] + '"');
         }
         else
@@ -246,7 +246,7 @@ var SmExim = {
         }
         if (cEncloser == "din") {
           if (typeof row[iCol] == "string") {
-            row[iCol] = row[iCol].replace("\"", "\"\"", "g");
+            row[iCol] = row[iCol].replace(/"/g,"\"\"");
             row[iCol] = '"' + row[iCol] + '"';
           }
            data.push(row[iCol]);
@@ -254,7 +254,7 @@ var SmExim = {
         }
         if (cEncloser == '"') {
           if (typeof row[iCol] == "string") {
-            row[iCol] = row[iCol].replace("\"", "\"\"", "g");
+            row[iCol] = row[iCol].replace(/"/g,"\"\"");
           }
           row[iCol] = '"' + row[iCol] + '"';
            data.push(row[iCol]);

--- a/sqlite-manager/chrome/content/treeDataTable.js
+++ b/sqlite-manager/chrome/content/treeDataTable.js
@@ -256,7 +256,7 @@ TreeDataTable.prototype = {
       }
       else {
         if (typeof txt == "string")
-          txt = txt.replace("\"", "\"\"", "g");
+          txt = txt.replace(/"/g,"\"\"");
         txt = '"' + txt + '"';
       }
       result.push(txt);

--- a/sqlite-manager/chrome/resource/sqlite.js
+++ b/sqlite-manager/chrome/resource/sqlite.js
@@ -1406,7 +1406,7 @@ var SQLiteFn = {
 
   quote: function(str) {
     if (typeof str == "string")
-      str = str.replace("'", "''", "g");
+      str = str.replace(/'/g,"''");
     return "'" + str + "'";
   },
 
@@ -1544,7 +1544,7 @@ function getCsvRowFromArray(arrRow, arrTypes, oCsv) {
         break;
       case SQLiteTypes.TEXT:
       default:
-        arrRow[i] = arrRow[i].replace("\"", "\"\"", "g");
+        arrRow[i] = arrRow[i].replace(/"/g,"\"\"");
         arrRow[i] = '"' + arrRow[i] + '"';
         break;
     }


### PR DESCRIPTION
I add some trouble when importing an exported sql script to a new database.
As I found out, only the first quote(') in each string was replaced with ('') when exporting a database as sql script. This led to the issues when importing an sql scrit

I modified the calls to replace, because the third argument of String.replace isn't supported anymore in recent firefox versions. (see https://bugzilla.mozilla.org/show_bug.cgi?id=1108382)
